### PR TITLE
Elasticsearch setup and config

### DIFF
--- a/manifests/repo/elasticsearch.pp
+++ b/manifests/repo/elasticsearch.pp
@@ -1,11 +1,12 @@
 class p::repo::elasticsearch (
+  $version = '1.6'
 ) {
 
   p::resource::apt::repo { 'elasticsearch':
-    location   => 'http://packages.elasticsearch.org/elasticsearch/1.6/debian',
+    location   => "http://packages.elastic.co/elasticsearch/${version}/debian",
     release    => 'stable',
     repos      => 'main',
-    key        => 'D27D666CD88E42B4',
+    key        => 'D88E42B4',
     key_server => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch',
   }
 

--- a/manifests/server/elasticsearch.pp
+++ b/manifests/server/elasticsearch.pp
@@ -1,11 +1,48 @@
 class p::server::elasticsearch (
-  $version  = undef
+  $firewall      = true,
+  $port          = 9200,
+  $repo_version  = hiera('elasticsearch_repo_version', undef),
+  $version       = hiera('elasticsearch_version', undef),
+  $data_dir      = hiera('elasticsearch_data_dir', '/var/lib/elasticsearch/data'),
+  $listen_only   = hiera('elasticsearch_listen_only', undef),
 ) {
 
   if !defined(Class['p::repo::elasticsearch']) {
-    class {'p::repo::elasticsearch': }
+    class {'p::repo::elasticsearch': version => $repo_version }
   }
 
-   p::resource::package { 'elasticsearch': version => $version }
+     p::resource::package       { 'openjdk-7-jre': }
+  -> p::resource::package       { 'elasticsearch': version => $version }
+  -> p::resource::firewall::tcp { 'elasticsearch': enabled => $firewall, port => $port }
+  -> p::resource::directory     { "${data_dir}": owner => 'elasticsearch', group => 'elasticsearch', recurse => true }
+  -> service                    { 'elasticsearch': ensure => 'running', enable => true }
+
+  file_line { 'elasticsearch change listen port':
+    require => [P::Resource::Package['elasticsearch']],
+    path    => '/etc/elasticsearch/elasticsearch.yml',
+    line    => " http.port: ${port}",
+    match   => '^(\#)? http.port\:',
+    notify   => Service['elasticsearch'],
+  }
+
+  if ($listen_only) {
+    file_line { 'elasticsearch enable listen on specified interfaces':
+      require => [P::Resource::Package['elasticsearch']],
+      path    => '/etc/elasticsearch/elasticsearch.yml',
+      line    => " network.host: ${listen_only}",
+      match   => '^(\#)? network.host\:',
+      notify   => Service['elasticsearch'],
+    }
+  }
+
+  if ($data_dir) {
+    file_line { 'elasticsearch change data directory':
+      require => [P::Resource::Package['elasticsearch']],
+      path    => '/etc/elasticsearch/elasticsearch.yml',
+      line    => " path.data: ${data_dir}",
+      match   => '^(\#)? path.data\:',
+      notify   => Service['elasticsearch'],
+    }
+  }
 
 }


### PR DESCRIPTION
Supports ES 2.0 repository
Backward compatible, default repository is ES 1.6
